### PR TITLE
Display message returned by Bintray REST API when a request fails.

### DIFF
--- a/src/main/groovy/com/jfrog/bintray/gradle/BintrayUploadTask.groovy
+++ b/src/main/groovy/com/jfrog/bintray/gradle/BintrayUploadTask.groovy
@@ -193,9 +193,9 @@ class BintrayUploadTask extends DefaultTask {
                 response.success = { resp ->
                     logger.info("Attributes set on $entity '$entityName'.")
                 }
-                response.failure = { resp ->
+                response.failure = { resp, json ->
                     throw new GradleException(
-                            "Could not set attributes on $entity '$entityName': $resp.statusLine")
+                            "Could not set attributes on $entity '$entityName': $json.message")
                 }
             }
         }
@@ -226,8 +226,8 @@ class BintrayUploadTask extends DefaultTask {
                     response.success = { resp ->
                         logger.info("Created package '$packagePath'.")
                     }
-                    response.failure = { resp ->
-                        throw new GradleException("Could not create package '$packagePath': $resp.statusLine")
+                    response.failure = { resp, json ->
+                        throw new GradleException("Could not create package '$packagePath': $json.message")
                     }
                 }
                 if (packageAttributes) {
@@ -260,8 +260,8 @@ class BintrayUploadTask extends DefaultTask {
                     response.success = { resp ->
                         logger.info("Created version '$versionName'.")
                     }
-                    response.failure = { resp ->
-                        throw new GradleException("Could not create version '$versionName': $resp.statusLine")
+                    response.failure = { resp, json ->
+                        throw new GradleException("Could not create version '$versionName': $json.message")
                     }
                 }
                 if (versionAttributes) {
@@ -284,8 +284,8 @@ class BintrayUploadTask extends DefaultTask {
                 response.success = { resp ->
                     logger.info("Signed version '$versionName'.")
                 }
-                response.failure = { resp ->
-                    throw new GradleException("Could not sign version '$versionName': $resp.statusLine")
+                response.failure = { resp, json ->
+                    throw new GradleException("Could not sign version '$versionName': $json.message")
                 }
             }
         }


### PR DESCRIPTION
Currently, Bintray REST API calls made by the `BintrayUploadTask` simply return the HTTP message status code when an error occurs. This is typically in the form of "400 - Bad Request" which is not very useful to the user. However, the REST API provides a JSON response in these cases, in the form of `{ "message" : "Reason error occured." }. Pull request changes includes displaying this text to the user rather than just the response status.