### PR TITLE
Add an optional property for disabling the Maven Central Sync.

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ bintray {
                 passphrase = 'passphrase' //Optional. The passphrase for GPG signing'
             }
 			mavenCentralSync {
+                sync = true //Optional (true by default). Determines whether to sync the version to Maven Central.
 				user = 'userToken' //OSS user token
 				password = 'paasword' //OSS user password
 				close = '1' //Optional property. By default the staging repository is closed and artifacts are released to Maven Central. You can optionally turn this behaviour off (by puting 0 as value) and release the version manually.

--- a/src/main/groovy/com/jfrog/bintray/gradle/BintrayExtension.groovy
+++ b/src/main/groovy/com/jfrog/bintray/gradle/BintrayExtension.groovy
@@ -86,6 +86,7 @@ class BintrayExtension {
     }
 
     class MavenCentralSyncConfig {
+        Boolean sync
         String user
         String password
         String close

--- a/src/main/groovy/com/jfrog/bintray/gradle/BintrayPlugin.groovy
+++ b/src/main/groovy/com/jfrog/bintray/gradle/BintrayPlugin.groovy
@@ -55,6 +55,8 @@ class BintrayPlugin implements Plugin<Project> {
                         versionAttributes = extension.pkg.version.attributes
                         signVersion = extension.pkg.version.gpg.sign
                         gpgPassphrase = extension.pkg.version.gpg.passphrase
+                        syncToMavenCentral = extension.pkg.version.mavenCentralSync.sync == null ?
+                            true : extension.pkg.version.mavenCentralSync.sync
                         ossUser = extension.pkg.version.mavenCentralSync.user
                         ossPassword = extension.pkg.version.mavenCentralSync.password
                         ossCloseRepo = extension.pkg.version.mavenCentralSync.close

--- a/src/main/groovy/com/jfrog/bintray/gradle/BintrayUploadTask.groovy
+++ b/src/main/groovy/com/jfrog/bintray/gradle/BintrayUploadTask.groovy
@@ -128,6 +128,10 @@ class BintrayUploadTask extends DefaultTask {
 
     @Input
     @Optional
+    boolean syncToMavenCentral
+
+    @Input
+    @Optional
     String ossUser
 
     @Input
@@ -387,7 +391,7 @@ class BintrayUploadTask extends DefaultTask {
         if (publish && !subtaskSkipPublish) {
             publishVersion()
         }
-        if (ossUser != null && ossPassword != null) {
+        if (syncToMavenCentral && ossUser != null && ossPassword != null) {
             mavenCentralSync()
         }
     }


### PR DESCRIPTION
Add an optional property to the mavenCentralSync closure for disabling the Maven Central Sync.
