### PR TITLE
Fix filesSpec path issues when running on windows

### DIFF
--- a/src/main/groovy/com/jfrog/bintray/gradle/RecordingCopyTask.groovy
+++ b/src/main/groovy/com/jfrog/bintray/gradle/RecordingCopyTask.groovy
@@ -24,7 +24,7 @@ class RecordingCopyTask extends Copy {
                     FileCopyDetailsInternal details ->
                         if (!details.isDirectory()) {
                             File target = resolver.resolve(details.getRelativePath().getPathString());
-                            def destRelPath = project.relativePath(target)
+                            def destRelPath = project.relativePath(target).replaceAll('\\\\','/')
                             fileUploads << new Artifact(file: details.file, path: destRelPath)
                             didWork = true
                         }


### PR DESCRIPTION
When running on windows, the target file paths are concatenated using the environment's file separator (which is '\' on Windows).
When using filesSpec for uploading specific files, the generated URL can be for example:
https://api.bintray.com/content/myuser/myrepo/mypackage/1.0.0/foo\bar\myfile.ext
(note the slashes in the lasts parts)