### PR TITLE
Fix path name generation for Signature artifacts

### DIFF
--- a/src/main/groovy/com/jfrog/bintray/gradle/BintrayUploadTask.groovy
+++ b/src/main/groovy/com/jfrog/bintray/gradle/BintrayUploadTask.groovy
@@ -404,9 +404,13 @@ class BintrayUploadTask extends DefaultTask {
                 return null
             }
             pomArtifact = !pomArtifact && it.type == 'pom'
-            new Artifact(
-                    name: it.name, groupId: project.group, version: project.version, extension: it.extension,
-                    type: it.type, classifier: it.classifier, file: it.file)
+            if (it instanceof org.gradle.plugins.signing.Signature)
+                new Signature(
+                        name: it.name, groupId: project.group, version: project.version,
+                        extension: it.extension, type: it.type, classifier: it.classifier,
+                        file: it.file, signedArtifact: createArtifact(it.toSignArtifact))
+            else
+                createArtifact(it)
         }.unique();
 
         //Add pom file per config
@@ -438,5 +442,12 @@ class BintrayUploadTask extends DefaultTask {
                 name: identity.artifactId, groupId: identity.groupId, version: identity.version,
                 extension: 'pom', type: 'pom', file: publication.asNormalisedPublication().pomFile)
         artifacts
+    }
+
+    Artifact createArtifact(artifact) {
+        return new Artifact(
+                name: artifact.name, groupId: project.group, version: project.version,
+                extension: artifact.extension, type: artifact.type,
+                classifier: artifact.classifier, file: artifact.file)
     }
 }

--- a/src/main/groovy/com/jfrog/bintray/gradle/Signature.groovy
+++ b/src/main/groovy/com/jfrog/bintray/gradle/Signature.groovy
@@ -1,0 +1,28 @@
+package com.jfrog.bintray.gradle
+
+class Signature extends Artifact {
+    Artifact signedArtifact
+
+    @Override
+    def getPath() {
+        signedArtifact.path + "." + extension
+    }
+
+    boolean equals(o) {
+        if (!super.equals(o)) {
+            return false
+        }
+
+        Signature sig = (Signature) o
+
+        if (signedArtifact != sig.signedArtifact) {
+            return false
+        }
+
+        return true
+    }
+
+    int hashCode() {
+        return 31 * super.hashCode() + (signedArtifact != null ? signedArtifact.hashCode() : 0)
+    }
+}


### PR DESCRIPTION
Fix for issue: #53.

Currently the filename for artifacts is recreated from their information
like classifier, extension, &c. However, this does not work for
signatures.  Their extension is "asc". The artifact name however is
based on the original artifact. Therefor this information has to be
tracked in order to correctly upload the artifacts' signatures.

Example upload before:

    Uploading to https://api.bintray.com/content/kotarak/kotkade/gradle-plugin/1.4.0/de/kotka/gradle/gradle-plugin/1.4.0/gradle-plugin-1.4.0.jar...
    Uploaded to 'https://api.bintray.com/content/kotarak/kotkade/gradle-plugin/1.4.0/de/kotka/gradle/gradle-plugin/1.4.0/gradle-plugin-1.4.0.jar'.
    Uploading to https://api.bintray.com/content/kotarak/kotkade/gradle-plugin/1.4.0/de/kotka/gradle/gradle-plugin/1.4.0/gradle-plugin-1.4.0.pom...
    Uploaded to 'https://api.bintray.com/content/kotarak/kotkade/gradle-plugin/1.4.0/de/kotka/gradle/gradle-plugin/1.4.0/gradle-plugin-1.4.0.pom'.
    Uploading to https://api.bintray.com/content/kotarak/kotkade/gradle-plugin/1.4.0/de/kotka/gradle/gradle-plugin/1.4.0/gradle-plugin-1.4.0.asc...
    Uploaded to 'https://api.bintray.com/content/kotarak/kotkade/gradle-plugin/1.4.0/de/kotka/gradle/gradle-plugin/1.4.0/gradle-plugin-1.4.0.asc'.
    Uploading to https://api.bintray.com/content/kotarak/kotkade/gradle-plugin/1.4.0/de/kotka/gradle/gradle-plugin/1.4.0/gradle-plugin-1.4.0.asc...
    Uploaded to 'https://api.bintray.com/content/kotarak/kotkade/gradle-plugin/1.4.0/de/kotka/gradle/gradle-plugin/1.4.0/gradle-plugin-1.4.0.asc'.

Example upload after:

    Uploading to https://api.bintray.com/content/kotarak/kotkade/gradle-plugin/1.4.0/de/kotka/gradle/gradle-plugin/1.4.0/gradle-plugin-1.4.0.jar...
    Uploaded to 'https://api.bintray.com/content/kotarak/kotkade/gradle-plugin/1.4.0/de/kotka/gradle/gradle-plugin/1.4.0/gradle-plugin-1.4.0.jar'.
    Uploading to https://api.bintray.com/content/kotarak/kotkade/gradle-plugin/1.4.0/de/kotka/gradle/gradle-plugin/1.4.0/gradle-plugin-1.4.0.pom...
    Uploaded to 'https://api.bintray.com/content/kotarak/kotkade/gradle-plugin/1.4.0/de/kotka/gradle/gradle-plugin/1.4.0/gradle-plugin-1.4.0.pom'.
    Uploading to https://api.bintray.com/content/kotarak/kotkade/gradle-plugin/1.4.0/de/kotka/gradle/gradle-plugin/1.4.0/gradle-plugin-1.4.0.jar.asc...
    Uploaded to 'https://api.bintray.com/content/kotarak/kotkade/gradle-plugin/1.4.0/de/kotka/gradle/gradle-plugin/1.4.0/gradle-plugin-1.4.0.jar.asc'.
    Uploading to https://api.bintray.com/content/kotarak/kotkade/gradle-plugin/1.4.0/de/kotka/gradle/gradle-plugin/1.4.0/gradle-plugin-1.4.0.pom.asc...
    Uploaded to 'https://api.bintray.com/content/kotarak/kotkade/gradle-plugin/1.4.0/de/kotka/gradle/gradle-plugin/1.4.0/gradle-plugin-1.4.0.pom.asc'.
