### PR TITLE
Take dependency on local publish task via task name.

### DIFF
--- a/src/main/groovy/com/jfrog/bintray/gradle/BintrayPlugin.groovy
+++ b/src/main/groovy/com/jfrog/bintray/gradle/BintrayPlugin.groovy
@@ -92,8 +92,7 @@ class BintrayPlugin implements Plugin<Project> {
                                 } else if (publication instanceof MavenPublication) {
                                     def taskName =
                                             "publish${it[0].toUpperCase()}${it.substring(1)}PublicationToMavenLocal"
-                                    Task publishToLocalTask = project.tasks.findByName(taskName)
-                                    bintrayUpload.dependsOn(publishToLocalTask)
+                                    bintrayUpload.dependsOn(taskName)
                                     /*bintrayUpload.dependsOn(publication.publishableFiles)*/
                                 } else {
                                     project.logger.warn "{} can only use maven publications - skipping {}.",


### PR DESCRIPTION
This is required from Gradle 2.4 on due to changes in the publishing stuff. The change is backwards compatible.

It would be great if you could test the plugin with the latest nightly.