### PR TITLE
Print gradle process log to screen

### DIFF
--- a/src/test/groovy/com/jfrog/bintray/gradle/GradleBintrayPluginSpec.groovy
+++ b/src/test/groovy/com/jfrog/bintray/gradle/GradleBintrayPluginSpec.groovy
@@ -4,8 +4,8 @@ import com.jfrog.bintray.client.api.handle.Bintray
 import com.jfrog.bintray.client.api.model.Pkg
 import org.junit.Rule
 import org.junit.rules.TestName
-import spock.lang.Specification
 import spock.lang.Shared
+import spock.lang.Specification
 
 class GradleBintrayPluginSpec extends Specification {
 
@@ -14,7 +14,7 @@ class GradleBintrayPluginSpec extends Specification {
     @Shared
     private Bintray bintray = PluginSpecUtils.getBintrayClient()
     @Shared
-    private def config = TestsConfig.getInstance().confog
+    private def config = TestsConfig.getInstance().config
 
     def setupSpec() {
         assert config

--- a/src/test/groovy/com/jfrog/bintray/gradle/PluginSpecUtils.groovy
+++ b/src/test/groovy/com/jfrog/bintray/gradle/PluginSpecUtils.groovy
@@ -8,7 +8,7 @@ import com.jfrog.bintray.client.impl.BintrayClient
  */
 class PluginSpecUtils {
     private static Bintray bintrayClient
-    private static def config = TestsConfig.getInstance().confog
+    private static def config = TestsConfig.getInstance().config
 
     def static getGradleCommandPath() {
         System.getenv("GRADLE_HOME") + File.separator + "bin" + File.separator + "gradle.bat"
@@ -21,9 +21,8 @@ class PluginSpecUtils {
 
     def static GradleLauncher createGradleLauncher() {
         File projectFile = getGradleProjectFile()
-        def gradleLogPath = projectFile.getParentFile().getCanonicalPath()
         GradleLauncher launcher = new GradleLauncher(
-                getGradleCommandPath(), projectFile.getCanonicalPath(), gradleLogPath)
+                getGradleCommandPath(), projectFile.getCanonicalPath())
                 .addTask("clean")
                 .addTask("bintrayUpload")
                 .addEnvVar("bintrayUser", config.bintrayUser)
@@ -34,10 +33,8 @@ class PluginSpecUtils {
                 .addEnvVar("versionName", config.versionName)
                 .addSwitch("stacktrace")
 
-        int i=1
-        for(label in config.pkgLabels) {
-            launcher.addEnvVar("label${i}", label)
-            i++
+        config.pkgLabels.eachWithIndex { label, index ->
+            launcher.addEnvVar("label${index+1}", label)
         }
         launcher
     }

--- a/src/test/groovy/com/jfrog/bintray/gradle/TestsConfig.groovy
+++ b/src/test/groovy/com/jfrog/bintray/gradle/TestsConfig.groovy
@@ -7,40 +7,40 @@ import static java.lang.System.getenv
  */
 class TestsConfig {
     private static TestsConfig instance = new TestsConfig()
-    public def confog
+    public def config
 
     static TestsConfig getInstance() {
         return instance
     }
 
     private TestsConfig() {
-        confog = new ConfigSlurper().parse(this.class.getResource('/gradle/config.groovy')).conf
+        config = new ConfigSlurper().parse(this.class.getResource('/gradle/config.groovy')).conf
 
         def bintrayUser = getenv('BINTRAY_USER')
         if (bintrayUser) {
-            confog.bintrayUser = bintrayUser
+            config.bintrayUser = bintrayUser
         }
         def bintrayApiKey = getenv('BINTRAY_KEY')
         if (bintrayApiKey) {
-            confog.bintrayApiKey = bintrayApiKey
+            config.bintrayApiKey = bintrayApiKey
         }
-        if (confog.url == [:]) {
-            confog.url = "https://api.bintray.com"
+        if (config.url == [:]) {
+            config.url = "https://api.bintray.com"
         }
-        if (confog.repo == [:]) {
-            confog.repo = "maven"
+        if (config.repo == [:]) {
+            config.repo = "maven"
         }
-        if (confog.pkgName == [:]) {
-            confog.pkgName = "gradle.tests.pkg.name"
+        if (config.pkgName == [:]) {
+            config.pkgName = "gradle.tests.pkg.name"
         }
-        if (confog.pkgDesc == [:]) {
-            confog.pkgDesc = "gradle.tests.pkg.description"
+        if (config.pkgDesc == [:]) {
+            config.pkgDesc = "gradle.tests.pkg.description"
         }
-        if (confog.versionName == [:]) {
-            confog.versionName = "9.8.7"
+        if (config.versionName == [:]) {
+            config.versionName = "9.8.7"
         }
-        if (confog.pkgLabels == [:]) {
-            confog.pkgLabels = ['a','b','c']
+        if (config.pkgLabels == [:]) {
+            config.pkgLabels = ['a','b','c']
         }
     }
 }


### PR DESCRIPTION
In the "test" task: The Gradle process - which we are creating for testing - log will now print directly to stdout without the need of creating temporary file and deleting it at the end of the test.