### PR TITLE
Retry publishing uploaded artifacts if it times out

### DIFF
--- a/src/main/groovy/com/jfrog/bintray/gradle/BintrayUploadTask.groovy
+++ b/src/main/groovy/com/jfrog/bintray/gradle/BintrayUploadTask.groovy
@@ -2,6 +2,7 @@ package com.jfrog.bintray.gradle
 
 import groovy.json.JsonBuilder
 import groovyx.net.http.HTTPBuilder
+import org.apache.http.impl.client.AutoRetryHttpClient
 import org.gradle.api.DefaultTask
 import org.gradle.api.GradleException
 import org.gradle.api.Task
@@ -342,6 +343,10 @@ class BintrayUploadTask extends DefaultTask {
                 logger.info("(Dry run) Pulished verion '$packagePath/$versionName'.")
                 return
             }
+
+            // If there are a lot of big artifacts, synchronous publishing can time out. Retrying that is perfectly fine.
+            http.client = new AutoRetryHttpClient(http.client, new CustomizableServiceUnavailableRetryStrategy(408, 10, 0))
+
             http.request(POST, JSON) {
                 uri.path = publishUri
                 // In case Maven Central Sync is configured, add this header to the publish request

--- a/src/main/groovy/com/jfrog/bintray/gradle/CustomizableServiceUnavailableRetryStrategy.groovy
+++ b/src/main/groovy/com/jfrog/bintray/gradle/CustomizableServiceUnavailableRetryStrategy.groovy
@@ -1,0 +1,42 @@
+package com.jfrog.bintray.gradle
+
+import org.apache.http.HttpResponse;
+import org.apache.http.annotation.Immutable;
+import org.apache.http.client.ServiceUnavailableRetryStrategy;
+import org.apache.http.protocol.HttpContext;
+
+/**
+ * Exactly the same as DefaultServiceUnavailableRetryStrategy, except it takes the response code to retry on
+ * as a parameter.
+ */
+@Immutable
+public class CustomizableServiceUnavailableRetryStrategy implements ServiceUnavailableRetryStrategy {
+	private int maxRetries;
+	private long retryInterval;
+	private int responseCode
+
+	public CustomizableServiceUnavailableRetryStrategy(int responseCode, int maxRetries, int retryInterval) {
+		if(maxRetries < 1) {
+			throw new IllegalArgumentException("MaxRetries must be greater than 1");
+		} else if(retryInterval < 1) {
+			throw new IllegalArgumentException("Retry interval must be greater than 1");
+		} else {
+			this.maxRetries = maxRetries;
+			this.retryInterval = (long)retryInterval;
+			this.responseCode = responseCode;
+		}
+	}
+
+	public CustomizableServiceUnavailableRetryStrategy() {
+		this(503, 1, 1000);
+	}
+
+	public boolean retryRequest(HttpResponse response, int executionCount, HttpContext context) {
+		return executionCount <= this.maxRetries && response.getStatusLine().getStatusCode() == this.responseCode;
+	}
+
+	public long getRetryInterval() {
+		return this.retryInterval;
+	}
+}
+


### PR DESCRIPTION
In a build with lots of artifacts (some of them quite big), we started experiencing errors like `HTTP/1.1 408 Request Timeout [message:Request timeout for publishing /openzipkin/zipkin/zipkin/1.2.1-rc16]` after enabling Maven Central sync. For an example, see https://travis-ci.org/openzipkin/zipkin/jobs/76288195

This PR enables a couple of retries to make that not an issue. One concern is that the number of retries is now hard-coded in the plugin; ideally that'd be configurable, but my hope is that this is good enough for an initial improvement.