### PR TITLE
Add github_repo and github_release_notes_file package properties support

### DIFF
--- a/src/main/groovy/com/jfrog/bintray/gradle/BintrayExtension.groovy
+++ b/src/main/groovy/com/jfrog/bintray/gradle/BintrayExtension.groovy
@@ -48,6 +48,8 @@ class BintrayExtension {
         String websiteUrl
         String issueTrackerUrl
         String vcsUrl
+        String githubRepo
+        String githubReleaseNotesFile
         boolean publicDownloadNumbers
         String[] licenses
         String[] labels

--- a/src/main/groovy/com/jfrog/bintray/gradle/BintrayPlugin.groovy
+++ b/src/main/groovy/com/jfrog/bintray/gradle/BintrayPlugin.groovy
@@ -44,6 +44,8 @@ class BintrayPlugin implements Plugin<Project> {
                         packageWebsiteUrl = extension.pkg.websiteUrl
                         packageIssueTrackerUrl = extension.pkg.issueTrackerUrl
                         packageVcsUrl = extension.pkg.vcsUrl
+                        packageGithubRepo = extension.pkg.githubRepo
+                        packageGithubReleaseNotesFile = extension.pkg.githubReleaseNotesFile
                         packageLicenses = extension.pkg.licenses
                         packageLabels = extension.pkg.labels
                         packageAttributes = extension.pkg.attributes

--- a/src/main/groovy/com/jfrog/bintray/gradle/BintrayUploadTask.groovy
+++ b/src/main/groovy/com/jfrog/bintray/gradle/BintrayUploadTask.groovy
@@ -86,6 +86,14 @@ class BintrayUploadTask extends DefaultTask {
 
     @Input
     @Optional
+    String packageGithubRepo
+
+    @Input
+    @Optional
+    String packageGithubReleaseNotesFile
+
+    @Input
+    @Optional
     String[] packageLicenses
 
     @Input
@@ -248,7 +256,8 @@ class BintrayUploadTask extends DefaultTask {
                     uri.path = "/packages/$repoPath"
                     body = [name                   : packageName, desc: packageDesc, licenses: packageLicenses, labels: packageLabels,
                             website_url            : packageWebsiteUrl, issue_tracker_url: packageIssueTrackerUrl, vcs_url: packageVcsUrl,
-                            public_download_numbers: packagePublicDownloadNumbers]
+                            public_download_numbers: packagePublicDownloadNumbers, github_repo: packageGithubRepo,
+                            github_release_notes_file: packageGithubReleaseNotesFile]
 
                     response.success = { resp ->
                         logger.info("Created package '$packagePath'.")

--- a/src/test/resources/gradle/buildFiles/create_package_and_version_with_fileSpec.gradle
+++ b/src/test/resources/gradle/buildFiles/create_package_and_version_with_fileSpec.gradle
@@ -18,6 +18,8 @@ bintray {
         websiteUrl = 'https://github.com/bintray/gradle-bintray-plugin'
         issueTrackerUrl = 'https://github.com/bintray/gradle-bintray-plugin/issues'
         vcsUrl = 'https://github.com/bintray/gradle-bintray-plugin.git'
+        githubRepo = 'bintray/gradle-bintray-plugin'
+        githubReleaseNotesFile = 'CHANGELOG.md'
         version {
             name = versionName
         }

--- a/src/test/resources/gradle/buildFiles/create_package_and_version_with_publication.gradle
+++ b/src/test/resources/gradle/buildFiles/create_package_and_version_with_publication.gradle
@@ -15,6 +15,8 @@ bintray {
         websiteUrl = 'https://github.com/bintray/gradle-bintray-plugin'
         issueTrackerUrl = 'https://github.com/bintray/gradle-bintray-plugin/issues'
         vcsUrl = 'https://github.com/bintray/gradle-bintray-plugin.git'
+        githubRepo = 'bintray/gradle-bintray-plugin'
+        githubReleaseNotesFile = 'CHANGELOG.md'
         version {
             name = versionName
             gpg {


### PR DESCRIPTION
Github properties are present in bintray rest docs: https://bintray.com/docs/api/#_create_package.
Adds 2 new properties to package configuration:
```
pkg {
        githubRepo = 'bintray/gradle-bintray-plugin'
        githubReleaseNotesFile = 'CHANGELOG.md'
}
```
Fixes #31