### PR TITLE
Fix Utils.toIsoDateFormat() for non-English locales.

### DIFF
--- a/src/main/groovy/com/jfrog/bintray/gradle/Utils.groovy
+++ b/src/main/groovy/com/jfrog/bintray/gradle/Utils.groovy
@@ -25,7 +25,7 @@ class Utils {
         } catch (ParseException e) {
         }
 
-        DateFormat dateToStringFormat = new SimpleDateFormat("EEE MMM dd HH:mm:ss zzz yyyy")
+        DateFormat dateToStringFormat = new SimpleDateFormat("EEE MMM dd HH:mm:ss zzz yyyy", Locale.ENGLISH)
         return isoFormat.format(dateToStringFormat.parse(dateString))
     }
 


### PR DESCRIPTION
When a user set bintray.pkg.version.released to a Date instance, its string representation will be passed to toIsoDateFormat() and parsed by the dateToStringFormat.
But in non-English locales such as Japanese, this parse fails because a Date instance is always converted to an English string but a SimpleDateFormat object instantiated without specifying a locale attempts to parse a given string in the JVM locale (i.e. non-English), which results in an error like "java.text.ParseException: Unparseable date: "Fri Apr 29 10:03:11 MDT 2016"".
To avoid this error, Locale.English is added to SimpleDateFormat's constructor.