### PR TITLE
fix typos and add clarifications in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,8 +65,8 @@ Mandatory parameters:
 
 1. repo - existing repository in bintray to add the artifacts to (for example: 'generic', 'maven' etc)
 2. name - package name
-3. licenses - your package licenses (mandatory if the package doesn't exist yet and must be created; optional otherwise)
-4. vcsUrl - your VCS URL (mandatory if the package doesn't exist yet and must be created; optional otherwise)
+3. licenses - your package licenses (mandatory if the package doesn't exist yet and must be created, and if the package is an OSS package; optional otherwise)
+4. vcsUrl - your VCS URL (mandatory if the package doesn't exist yet and must be created, and if the package is an OSS package; optional otherwise)
 
 Optional parameters:
 
@@ -211,9 +211,11 @@ The plugin allows using Bintray supports for files GPG signing. To have your Ver
 
 # Maven Central Sync
 The plugin allows using Bintray's interface with Maven Central. You can have the artifacts of a Version sent to Maven Central, by adding the adding the *mavenCentralSync* closure inside the *version* closure, as shown in the below *Plugin DSL* section.
+If that closure is omitted, the version will not be sent to Maven central.
+
 In order for this functionality to be enabled, you first must verify the following:
 * The Version belongs to a Repository whose type is Maven and the Version belongs to a Package that is [included in JCenter](https://bintray.com/docs/usermanual/uploads/uploads_includingyourpackagesinacentralrepository.html).
-* Your package must comply with the requirement of Maven Central (click [here](http://central.sonatype.org/pages/requirements.html) for more information).
+* Your package must comply with the requirement of Maven Central (click [here](http://central.sonatype.org/pages/requirements.html) for more information). In particular, files must be signed to be sent to Maven Central. So GPG file signing should also be enabled (see above) if Maven Central sync is enabled.
 
 # Plugin DSL
 The Gradle Bintray plugin can be configured using its own Convention DSL inside the build.gradle script of your root project.
@@ -268,8 +270,8 @@ bintray {
             //Optional configuration for Maven Central sync of the version
             mavenCentralSync {
                 sync = true //Optional (true by default). Determines whether to sync the version to Maven Central.
-                user = 'userToken' //OSS user token
-                password = 'paasword' //OSS user password
+                user = 'userToken' //OSS user token: mandatory
+                password = 'paasword' //OSS user password: mandatory
                 close = '1' //Optional property. By default the staging repository is closed and artifacts are released to Maven Central. You can optionally turn this behaviour off (by puting 0 as value) and release the version manually.
             }            
         }

--- a/README.md
+++ b/README.md
@@ -65,23 +65,23 @@ Mandatory parameters:
 
 1. repo - existing repository in bintray to add the artifacts to (for example: 'generic', 'maven' etc)
 2. name - package name
-3. licenses - your package licenses
-4. vcsUrl - your VCS URL
+3. licenses - your package licenses (mandatory if the package doesn't exist yet and must be created; optional otherwise)
+4. vcsUrl - your VCS URL (mandatory if the package doesn't exist yet and must be created; optional otherwise)
 
 Optional parameters:
 
 1. userOrg – an optional organization name when the repo belongs to one of the user's orgs. If not added will use 'BINTRAY_USER' by default
 
 ```groovy
-bintray {	
+bintray {   
     user = 'bintray_user'
     key = 'bintray_api_key'
     pkg {
-		repo = 'generic'
-		name = 'gradle-project'
-		userOrg = 'bintray_user'
-		licenses = ['Apache-2.0']
-		vcsUrl = 'https://github.com/bintray/gradle-bintray-plugin.git'
+        repo = 'generic'
+        name = 'gradle-project'
+        userOrg = 'bintray_user'
+        licenses = ['Apache-2.0']
+        vcsUrl = 'https://github.com/bintray/gradle-bintray-plugin.git'
     }
 }
 ```
@@ -97,21 +97,21 @@ Optional parameters:
 
 1. desc - Version description
 2. released - Date of the version release. Can accept one of the following formats: 
-	* Date in the format of 'yyyy-MM-dd'T'HH:mm:ss.SSSZZ'
-	* java.util.Date instance
+    * Date in the format of 'yyyy-MM-dd'T'HH:mm:ss.SSSZZ'
+    * java.util.Date instance
 3. vcsTag - Version control tag name
 4. attributes - Attributes to be attached to the version
-	
+    
 
 ```groovy
 pkg {
-	version {
-	            name = '1.0-Final'
-	            desc = 'Gradle Bintray Plugin 1.0 final'
-	            released  = new Date()
-	            vcsTag = '1.3.0'
-	            attributes = ['gradle-plugin': 'com.use.less:com.use.less.gradle:gradle-useless-plugin']
-        }
+    version {
+        name = '1.0-Final'
+        desc = 'Gradle Bintray Plugin 1.0 final'
+        released  = new Date()
+        vcsTag = '1.3.0'
+        attributes = ['gradle-plugin': 'com.use.less:com.use.less.gradle:gradle-useless-plugin']
+    }
 }
 ```
 
@@ -129,14 +129,14 @@ Below you can find an example for Maven Publication that can be added to your Gr
 
 ```groovy
 publishing {
-	publications {
-		MyPublication(MavenPublication) {
-			from components.java
-			groupId 'org.jfrog.gradle.sample'
-			artifactId 'gradle-project'
-			version '1.1'
-		}
-	}
+    publications {
+        MyPublication(MavenPublication) {
+            from components.java
+            groupId 'org.jfrog.gradle.sample'
+            artifactId 'gradle-project'
+            version '1.1'
+        }
+    }
 }
 ```
 
@@ -145,7 +145,7 @@ This Publication should be referenced from the bintray closure as follows:
 ```groovy
 bintray {
     user = 'bintray_user'
-    key = 'bintray_api_key'	
+    key = 'bintray_api_key' 
     publications = ['MyPublication'] 
 }
 ```
@@ -166,7 +166,7 @@ and the Configuration should be referenced from the bintray closure as follows:
 ```groovy
 bintray {
     user = 'bintray_user'
-    key = 'bintray_api_key'	
+    key = 'bintray_api_key' 
     configurations = ['archives']
 }
 ```
@@ -184,8 +184,8 @@ bintray {
     user = 'bintray_user'
     key = 'bintray_api_key'
     filesSpec {
-	 from 'build/libs'
-	 into 'standalone_files/level1'
+       from 'build/libs'
+       into 'standalone_files/level1'
     }
 }
 ```
@@ -203,11 +203,11 @@ bintray {
 * The plugin uses the specified Package and Version details, for example, the Package VCS URL, only for creating the Package and Version. The plugin will not attempt to update those properties if the Package or Version already exist.
 
 ## Mandatory properties
-* For the *pkg* closure, if the package already exists, the only mandatiry property is *name*. If the package does not exist, the *licenses* and *vcsUrl properties are manadatory for OSS packages.
-* For the *version* closure, the only mandatiry property is *name*.
+* For the *pkg* closure, if the package already exists, the only mandatory properties are *repo* and *name*. If the package does not exist, the *licenses* and *vcsUrl properties are manadatory for OSS packages.
+* For the *version* closure, the only mandatory property is *name*.
 
-# GPF File Signing
-The plugin allows using Bintray supports for files GPG signing. To have your Version files signed by Bintray, you first need to [configure your public and private GPG keys](https://bintray.com/docs/usermanual/interacting/interacting_editingyouruserprofile.html#anchorMANAGINGGPGKEYS) in Bintray, and then add the *gpg* closure inside the *version* closure as shown in the below *Plugin DSL* section.
+# GPG File Signing
+The plugin allows using Bintray supports for files GPG signing. To have your Version files signed by Bintray, you first need to [configure your public and private GPG keys](https://bintray.com/docs/usermanual/interacting/interacting_editingyouruserprofile.html#anchorMANAGINGGPGKEYS) in Bintray, and then add the *gpg* closure inside the *version* closure as shown in the below *Plugin DSL* section. If your GPG keys are not configured in Bintray and `sign` is true, then the files will be signed using Bintray's internal keys.
 
 # Maven Central Sync
 The plugin allows using Bintray's interface with Maven Central. You can have the artifacts of a Version sent to Maven Central, by adding the adding the *mavenCentralSync* closure inside the *version* closure, as shown in the below *Plugin DSL* section.
@@ -267,11 +267,11 @@ bintray {
             }
             //Optional configuration for Maven Central sync of the version
             mavenCentralSync {
-            	sync = true //Optional (true by default). Determines whether to sync the version to Maven Central.
-            	user = 'userToken' //OSS user token
-            	password = 'paasword' //OSS user password
-            	close = '1' //Optional property. By default the staging repository is closed and artifacts are released to Maven Central. You can optionally turn this behaviour off (by puting 0 as value) and release the version manually.
-			}            
+                sync = true //Optional (true by default). Determines whether to sync the version to Maven Central.
+                user = 'userToken' //OSS user token
+                password = 'paasword' //OSS user password
+                close = '1' //Optional property. By default the staging repository is closed and artifacts are released to Maven Central. You can optionally turn this behaviour off (by puting 0 as value) and release the version manually.
+            }            
         }
     }
 }


### PR DESCRIPTION
I mainly fixed typos and indentation, and added clarifications on mandatory properties (some sections contradicted each other).

I also added a clarification on GPG signing in case the keys are not configured in Bintray (Bintray signs with its own keys in that case), **but I'm not sure it's true**. The documentation of bintray says it's the case, which is why I added that clarification. 

Finally, I think the section about Maven sync could be clearer. For example, sync is true by default. Does that mean that, to disable sync, we must explicitly set this property to false? Or should we simply omit the mavenCentralSync block? 

Also, it's really odd that all boolean properties use a boolean, except `close`, which must be set to '1' or '0'.

It's also unclear what the `user` is for. Indeed, the repo configuration in Bintray allows configuring the sonatype user, and, IIRC, requests it when asking for Maven central sync from the UI. So, if we specify the user in the `mavenCentralSync` closure:
 - does it use that value instead of the value configured in the repo?
 - or does it use that value and overwrite the value configured in the repo?
 - or does it check that the value is the same as the one configured in the repo?

If we don't specify the user, is the user configured in the repo used? Is it a prerequisite, to have the user configured in the repo?

Finally, if Maven sync is set to true, will the plugin automatically sign the files (since signing is a maven central requirement), or is it necessary to enable gpg signing to enable Maven sync?