### PR TITLE
fixed version number to minor (1.7 => 1.7.3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ To apply the plugin, please add one of the following snippets to your `build.gra
 ###### Gradle >= 2.1
 ```groovy
 plugins {
-    id "com.jfrog.bintray" version "1.7"
+    id "com.jfrog.bintray" version "1.7.3"
 }
 ```
 * Currently the "plugins" notation cannot be used for applying the plugin for sub projects, when used from the root build script.
@@ -28,7 +28,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.7'
+        classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.7.3'
     }
 }
 apply plugin: 'com.jfrog.bintray'


### PR DESCRIPTION
version 1.7 contains some bugs, in particular: override=true works only for 1.7.1+. So we should either fix version, or add comment to override option in Readme.
See [issue 77](https://github.com/bintray/gradle-bintray-plugin/issues/77) for details.