### PR TITLE
Fix for crash on Exception in getCurrentTaskIndex()

### DIFF
--- a/src/main/groovy/com/jfrog/bintray/gradle/BintrayUploadTask.groovy
+++ b/src/main/groovy/com/jfrog/bintray/gradle/BintrayUploadTask.groovy
@@ -552,7 +552,8 @@ class BintrayUploadTask extends DefaultTask {
         List<BintrayUploadTask> tasks = allBintrayUploadTasks
         int currentTaskIndex = tasks.indexOf(this);
         if (currentTaskIndex == -1) {
-            throw new Exception("Could not find the current task {} in the task graph", getPath());
+            String path = getPath()
+            throw new Exception("Could not find the current task \"$path\" in the task graph");
         }
         currentTaskIndex
     }


### PR DESCRIPTION
The `Exception` in `BintrayUploadTask.getCurrentTaskIndex()` is constructed with 2 String arguments.
This results in a `GroovyRuntimeException` since such a constructor doesn't exist.

The fix in this PR builds the Exception message properly.

Crash:
```
[...]
Caused by: groovy.lang.GroovyRuntimeException: Could not find matching constructor for: java.lang.Exception(java.lang.String, java.lang.String)
        at com.jfrog.bintray.gradle.BintrayUploadTask.getCurrentTaskIndex(BintrayUploadTask.groovy:555)
        at com.jfrog.bintray.gradle.BintrayUploadTask_Decorated.getCurrentTaskIndex(Unknown Source)
        at org.gradle.internal.metaobject.BeanDynamicObject$MetaClassAdapter.getProperty(BeanDynamicObject.java:197)
        at org.gradle.internal.metaobject.BeanDynamicObject.getProperty(BeanDynamicObject.java:150)
        at org.gradle.internal.metaobject.CompositeDynamicObject.getProperty(CompositeDynamicObject.java:55)
        at org.gradle.internal.metaobject.AbstractDynamicObject.getProperty(AbstractDynamicObject.java:60)
        at com.jfrog.bintray.gradle.BintrayUploadTask_Decorated.getProperty(Unknown Source)
        at com.jfrog.bintray.gradle.BintrayUploadTask.isLastTask(BintrayUploadTask.groovy:544)
        at com.jfrog.bintray.gradle.BintrayUploadTask_Decorated.isLastTask(Unknown Source)
        at org.gradle.internal.metaobject.BeanDynamicObject$MetaClassAdapter.getProperty(BeanDynamicObject.java:197)
        at org.gradle.internal.metaobject.BeanDynamicObject.getProperty(BeanDynamicObject.java:150)
        at org.gradle.internal.metaobject.CompositeDynamicObject.getProperty(CompositeDynamicObject.java:55)
        at org.gradle.internal.metaobject.AbstractDynamicObject.getProperty(AbstractDynamicObject.java:60)
        at com.jfrog.bintray.gradle.BintrayUploadTask_Decorated.getProperty(Unknown Source)
        at com.jfrog.bintray.gradle.BintrayUploadTask.bintrayUpload(BintrayUploadTask.groovy:471)
        at org.gradle.internal.reflect.JavaMethod.invoke(JavaMethod.java:73)
        at org.gradle.api.internal.project.taskfactory.DefaultTaskClassInfoStore$StandardTaskAction.doExecute(DefaultTaskClassInfoStore.java:141)
        at org.gradle.api.internal.project.taskfactory.DefaultTaskClassInfoStore$StandardTaskAction.execute(DefaultTaskClassInfoStore.java:134)
        at org.gradle.api.internal.project.taskfactory.DefaultTaskClassInfoStore$StandardTaskAction.execute(DefaultTaskClassInfoStore.java:123)
        at org.gradle.api.internal.AbstractTask$TaskActionWrapper.execute(AbstractTask.java:632)
        at org.gradle.api.internal.AbstractTask$TaskActionWrapper.execute(AbstractTask.java:615)
        at org.gradle.api.internal.tasks.execution.ExecuteActionsTaskExecuter.executeAction(ExecuteActionsTaskExecuter.java:95)
        at org.gradle.api.internal.tasks.execution.ExecuteActionsTaskExecuter.executeActions(ExecuteActionsTaskExecuter.java:76)
        ... 89 more
```