### PR TITLE
Change log level for missing user properties

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,7 @@ gradle-bintray-plugin.iml
 gradle-bintray-plugin.ipr
 gradle-bintray-plugin.iws
 gradle.properties
+.idea/
+.gradle/
+.DS_STORE
+build/

--- a/build.gradle
+++ b/build.gradle
@@ -112,7 +112,7 @@ publishing {
 
 task createReleasePropertiesFile(type:Exec) {
     String fileName = 'bintray.plugin.release.properties'
-    println 'Creating $fileName'
+    println "Creating $fileName"
     String fileContent = "version=$currentVersion"
     (new File("$rootDir/src/main/resources/$fileName")).write(fileContent)
 }

--- a/src/main/groovy/com/jfrog/bintray/gradle/BintrayHttpClientFactory.groovy
+++ b/src/main/groovy/com/jfrog/bintray/gradle/BintrayHttpClientFactory.groovy
@@ -25,7 +25,7 @@ class BintrayHttpClientFactory {
     static HTTPBuilder create(apiUrl, user, apiKey) {
         def assertNotEmpty = { String name, String val ->
             if (val?.isEmpty()) {
-                throw new IllegalArgumentException("Bintray $name cannot be empty!");
+                throw new IllegalArgumentException("Bintray $name cannot be empty!")
             }
         }
         assertNotEmpty('apiUrl', apiUrl)
@@ -80,7 +80,7 @@ class BintrayHttpClientFactory {
 
         if (System.getProperty('http.proxyHost')) {
             String proxyHost = System.getProperty('http.proxyHost')
-            Integer proxyPort = Integer.parseInt(System.getProperty('http.proxyPort', '80'));
+            Integer proxyPort = Integer.parseInt(System.getProperty('http.proxyPort', '80'))
             String proxyUser = System.getProperty('http.proxyUser')
             String proxyPassword = System.getProperty('http.proxyPassword', '')
             logger.info "Using proxy ${proxyUser}:${proxyPassword}@${proxyHost}:${proxyPort}"

--- a/src/main/groovy/com/jfrog/bintray/gradle/BintrayPlugin.groovy
+++ b/src/main/groovy/com/jfrog/bintray/gradle/BintrayPlugin.groovy
@@ -11,7 +11,7 @@ class BintrayPlugin implements Plugin<Project> {
     private Project project
 
     public void apply(Project project) {
-        this.project = project;
+        this.project = project
 
         //Create and configure the task
         BintrayUploadTask bintrayUpload = project.task(type: BintrayUploadTask, BintrayUploadTask.NAME)

--- a/src/main/groovy/com/jfrog/bintray/gradle/BintrayUploadTask.groovy
+++ b/src/main/groovy/com/jfrog/bintray/gradle/BintrayUploadTask.groovy
@@ -182,9 +182,9 @@ class BintrayUploadTask extends DefaultTask {
 
     @TaskAction
     void bintrayUpload() {
-        logger.info("Gradle Bintray Plugin version: ${new Utils().pluginVersion}");
+        logger.info("Gradle Bintray Plugin version: ${new Utils().pluginVersion}")
         if (shouldSkip()) {
-            logger.info("Skipping task '{}:bintrayUpload' because user or apiKey is null.", this.project.name);
+            logger.info("Skipping task '{}:bintrayUpload' because user or apiKey is null.", this.project.name)
             return
         }
         validateDebianDefinition()
@@ -212,7 +212,7 @@ class BintrayUploadTask extends DefaultTask {
                 if (publication != null) {
                     return collectArtifacts(publication)
                 } else {
-                    logger.error("{}: Could not find publication: {}.", path, it);
+                    logger.error("{}: Could not find publication: {}.", path, it)
                 }
             } else if (conf instanceof MavenPublication) {
                 return collectArtifacts((Configuration) it)
@@ -254,7 +254,7 @@ class BintrayUploadTask extends DefaultTask {
             // Check if the package has already been created by another BintrayUploadTask.
             Package pkg = checkPackageAlreadyCreated()
             if (pkg && pkg.isCreated()) {
-                return;
+                return
             }
             def create
             http.request(HEAD) {
@@ -304,7 +304,7 @@ class BintrayUploadTask extends DefaultTask {
             // Check if the version has already been created by another BintrayUploadTask.
             Version version = checkVersionAlreadyCreated()
             if (version && version.isCreated()) {
-                return;
+                return
             }
             def create
             http.request(HEAD) {
@@ -565,9 +565,9 @@ class BintrayUploadTask extends DefaultTask {
      */
     int getCurrentTaskIndex() {
         List<BintrayUploadTask> tasks = allBintrayUploadTasks
-        int currentTaskIndex = tasks.indexOf(this);
+        int currentTaskIndex = tasks.indexOf(this)
         if (currentTaskIndex == -1) {
-            throw new Exception("Could not find the current task {} in the task graph", getPath());
+            throw new Exception("Could not find the current task {} in the task graph", getPath())
         }
         currentTaskIndex
     }
@@ -578,7 +578,7 @@ class BintrayUploadTask extends DefaultTask {
             for (Task task : getProject().getGradle().getTaskGraph().getAllTasks()) {
                 if (task instanceof BintrayUploadTask) {
                     if (!task.shouldSkip()) {
-                        tasks.add(task);
+                        tasks.add(task)
                     }
                 }
             }
@@ -605,10 +605,10 @@ class BintrayUploadTask extends DefaultTask {
                     name: it.name, groupId: project.group, version: project.version, extension: it.extension,
                     type: it.type, classifier: it.classifier, file: it.file, signedExtension: signedExtension
             )
-        }.unique();
+        }.unique()
 
         // Add pom file per config
-        Upload installTask = project.tasks.withType(Upload).findByName('install');
+        Upload installTask = project.tasks.withType(Upload).findByName('install')
         if (!installTask) {
             logger.info "maven plugin was not applied, no pom will be uploaded."
         } else if (!pomArtifact) {

--- a/src/main/groovy/com/jfrog/bintray/gradle/BintrayUploadTask.groovy
+++ b/src/main/groovy/com/jfrog/bintray/gradle/BintrayUploadTask.groovy
@@ -184,7 +184,7 @@ class BintrayUploadTask extends DefaultTask {
     void bintrayUpload() {
         logger.info("Gradle Bintray Plugin version: ${new Utils().pluginVersion}")
         if (shouldSkip()) {
-            logger.info("Skipping task '{}:bintrayUpload' because user or apiKey is null.", this.project.name)
+            logger.error("Skipping task '{}:bintrayUpload' because user or apiKey is null.", this.project.name)
             return
         }
         validateDebianDefinition()

--- a/src/main/groovy/com/jfrog/bintray/gradle/Utils.groovy
+++ b/src/main/groovy/com/jfrog/bintray/gradle/Utils.groovy
@@ -40,10 +40,10 @@ class Utils {
     }
 
     public static String readArtifactIdFromPom(File pom) {
-        FileReader reader = new FileReader(pom);
-        MavenXpp3Reader mavenreader = new MavenXpp3Reader();
-        Model model = mavenreader.read(reader);
-        MavenProject project = new MavenProject(model);
-        return project.getArtifactId();
+        FileReader reader = new FileReader(pom)
+        MavenXpp3Reader mavenreader = new MavenXpp3Reader()
+        Model model = mavenreader.read(reader)
+        MavenProject project = new MavenProject(model)
+        return project.getArtifactId()
     }
 }

--- a/src/test/groovy/com/jfrog/bintray/gradle/GradleLauncher.groovy
+++ b/src/test/groovy/com/jfrog/bintray/gradle/GradleLauncher.groovy
@@ -40,7 +40,7 @@ class GradleLauncher {
 
     private def tasksToString() {
         StringBuilder sb = new StringBuilder()
-        int c = 0;
+        int c = 0
         for(task in tasks) {
             sb.append(task)
             if (c++ < tasks.size()-1) {
@@ -52,7 +52,7 @@ class GradleLauncher {
 
     private def switchesToString() {
         StringBuilder sb = new StringBuilder()
-        int c = 0;
+        int c = 0
         for(gradleSwitch in switches) {
             gradleSwitch = gradleSwitch.startsWith("--") ? gradleSwitch : "--${gradleSwitch}"
             sb.append(gradleSwitch)
@@ -65,7 +65,7 @@ class GradleLauncher {
 
     private def envVarsToString() {
         StringBuilder sb = new StringBuilder()
-        int c = 0;
+        int c = 0
         for(var in envVars) {
             def key = var.key.startsWith("-P") ? var.key : "-P${var.key}"
             sb.append(key).append("=").append(var.value)
@@ -78,7 +78,7 @@ class GradleLauncher {
 
     private def systemPropsToString() {
         StringBuilder sb = new StringBuilder()
-        int c = 0;
+        int c = 0
         for(var in systemProps) {
             def key = var.key.startsWith("-D") ? var.key : "-D${var.key}"
             sb.append(key).append("=").append(var.value)


### PR DESCRIPTION
Fixes #204

### What has been done
- Missing apiKey/user error message log level change from `info` to `error` (see https://github.com/bintray/gradle-bintray-plugin/commit/de1c3ced0349e77dd222371bd5a27b724203c889)
- Ignored autogenerated project files
- General code clean up (removed semicolons)

### How to test
- Set `user` or `key` to `null` in `bintray` closure:
```
bintray {
    user = null
    key = null
}
```
- Execute `./gradlew clean build install bintrayUpload -DdryRun=true` command and observe logs

**Before the change**
```
:dependencies-overview:build
:dependencies-overview:install
:dependencies-overview:bintrayUpload

BUILD SUCCESSFUL
```

**After the change**
```
:dependencies-overview:build
:dependencies-overview:install
:dependencies-overview:bintrayUpload
Skipping task 'dependencies-overview:bintrayUpload' because user or apiKey is null.

BUILD SUCCESSFUL
```

