### PR TITLE
Feature/gradle kotlin dsl compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@ gradle-bintray-plugin.iml
 gradle-bintray-plugin.ipr
 gradle-bintray-plugin.iws
 gradle.properties
+.idea
+build
+src/main/resources/bintray.plugin.release.properties

--- a/src/main/groovy/com/jfrog/bintray/gradle/BintrayExtension.groovy
+++ b/src/main/groovy/com/jfrog/bintray/gradle/BintrayExtension.groovy
@@ -15,9 +15,9 @@ class BintrayExtension {
 
     PackageConfig pkg = new PackageConfig()
 
-    String[] configurations
+    List<String> configurations = new ArrayList<>()
 
-    String[] publications
+    List<String> publications = new ArrayList<>()
 
     RecordingCopyTask filesSpec
 
@@ -53,9 +53,9 @@ class BintrayExtension {
         String githubRepo
         String githubReleaseNotesFile
         boolean publicDownloadNumbers
-        String[] licenses
-        String[] labels
-        Map attributes
+        List<String> licenses = new ArrayList<>()
+        List<String> labels = new ArrayList<>()
+        Map attributes = new HashMap()
 
         VersionConfig version = new VersionConfig()
         def version(Closure closure) {

--- a/src/main/groovy/com/jfrog/bintray/gradle/BintrayPlugin.groovy
+++ b/src/main/groovy/com/jfrog/bintray/gradle/BintrayPlugin.groovy
@@ -68,7 +68,7 @@ class BintrayPlugin implements Plugin<Project> {
                     ossPassword = extension.pkg.version.mavenCentralSync.password
                     ossCloseRepo = extension.pkg.version.mavenCentralSync.close
                 }
-                if (extension.configurations?.length) {
+                if (!extension.configurations.isEmpty()) {
                     extension.configurations.each {
                         def configuration = project.configurations.findByName(it)
                         if (!configuration) {
@@ -86,7 +86,7 @@ class BintrayPlugin implements Plugin<Project> {
                                 project.path
                     }
                 }
-                if (extension.publications?.length) {
+                if (!extension.publications.isEmpty()) {
                     def publicationExt = project.extensions.findByType(PublishingExtension)
                     if (!publicationExt) {
                         project.logger.warn "Publications(s) specified but no publications exist in project {}.",

--- a/src/main/groovy/com/jfrog/bintray/gradle/BintrayUploadTask.groovy
+++ b/src/main/groovy/com/jfrog/bintray/gradle/BintrayUploadTask.groovy
@@ -101,11 +101,11 @@ class BintrayUploadTask extends DefaultTask {
 
     @Input
     @Optional
-    String[] packageLicenses
+    List<String> packageLicenses
 
     @Input
     @Optional
-    String[] packageLabels
+    List<String> packageLabels
 
     @Input
     @Optional


### PR DESCRIPTION
Hi,

I was converting my groovy gradle build files and was not able to assign publications on the extension class. These are really small changes that make it possible to use this plugin when using kotlin gradle build files.

What changed:
- replaced all String[] attributes on the BintrayExtension by List<String> and initialized them with empty lists.
- configurations and publications can now be properly added by using .add(...) on the initialized list attributes of BintrayExtension.
- aligned the types on the BintrayUploadTask for the licenses and labels attributes.
- updated the empty check on the publications and configurations attributes in the BintrayPlugin class.