### PR TITLE
Fix example in README with Android and the new 'implementation' or 'api' configurations

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,9 +250,9 @@ publishing {
     publications {
         MyPublication(MavenPublication) {
           // Define this explicitly if using implementation or api configurations
-          def dependenciesNode = asNode().getAt('dependencies')[0] ?: asNode().appendNode('dependencies')
-          
           pom.withXml {
+            def dependenciesNode = asNode().getAt('dependencies')[0] ?: asNode().appendNode('dependencies')
+          
             // Iterate over the implementation dependencies (we don't want the test ones), adding a <dependency> node for each
             configurations.implementation.allDependencies.each {
                // Ensure dependencies such as fileTree are not included.


### PR DESCRIPTION
Otherwise, the example given would not compile, with the following error:

```
> Could not find method asNode() for arguments [] on object of type org.gradle.api.publish.maven.internal.publication.DefaultMavenPublication.
```