### PR TITLE
Update publication artifact collection logic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,8 @@
 build
 
 gradle.properties
+
+build/
+.gradle/
+
+.idea/

--- a/README.md
+++ b/README.md
@@ -444,27 +444,51 @@ export BINTRAY_USER=<Your Bintray user name>
 export BINTRAY_KEY=<Your Bintray API Key>
 export BINTRAY_ORG=<Your Bintray organization name>
 ```
+## Publish the modified plugin to Maven local
+
+In order to test the modified plugin, it must be published to Maven local where the tests will resolve it.
+
+The publication can be done by running:
+```
+> ./gradlew publishtToMavenLocal
+```
+
+---
+**NOTE**
+
+If you have changed the plugin version in `gradle.properties`, you will need to change it in the test projects.
+See `src/test/resources/gradle/projects` for this.
+
+---
 
 ## Running the build with or without tests
 To build the code using the gradle wrapper in Unix run:
 ```
-> ./gradlew clean build
+> ./gradlew build
 ```
 
 To build the code using the gradle wrapper in Windows run:
 ```
-> gradlew clean build
+> gradlew build
 ```
 
 To build the code using the environment gradle run:
 ```
-> gradle clean build
+> gradle build
 ```
 
 To build the code without running the tests, add to the "clean build" command the "-x test" option, for example:
 ```
-> ./gradlew clean build -x test
+> ./gradlew build -x test
 ```
+
+---
+**NOTE**
+
+The tests will use the Gradle version pointed at by `GRADLE_HOME`.
+If not set, it will use the wrapper of this project.
+
+---
 
 <a name="Release_Notes"/>
 

--- a/build.gradle
+++ b/build.gradle
@@ -23,22 +23,21 @@ repositories {
 }
 
 dependencies {
-    compile gradleApi()
-    compile('org.codehaus.groovy.modules.http-builder:http-builder:0.7.2') {
+    implementation gradleApi()
+    implementation('org.codehaus.groovy.modules.http-builder:http-builder:0.7.2') {
         exclude(module: 'groovy')
     }
-    compile('org.apache.maven.resolver:maven-resolver-ant-tasks:1.2.0')
-    // provided by Gradle
-    compileOnly('org.apache.maven:maven-project:2.0.11')
-    testRuntime('org.apache.maven:maven-project:2.0.11')
-    testCompile('org.spockframework:spock-core:0.7-groovy-2.0') {
+    implementation('org.apache.maven.resolver:maven-resolver-ant-tasks:1.2.0')
+    implementation('org.apache.maven:maven-core:3.0.5')
+
+    testImplementation('org.spockframework:spock-core:0.7-groovy-2.0') {
         exclude(module: 'groovy-all')
     }
-    testCompile('com.jfrog.bintray.client:bintray-client-java-api:0.4')
-    testCompile('com.jfrog.bintray.client:bintray-client-java-service:0.4')
-    testCompile('com.jfrog.bintray.client:bintray-client-java-impl:0.1.1')
-    testCompile('org.codehaus.gpars:gpars:1.2.1')
-    testCompile('org.codehaus.groovy.modules.http-builder:http-builder:0.7.1')
+    testImplementation('com.jfrog.bintray.client:bintray-client-java-api:0.4')
+    testImplementation('com.jfrog.bintray.client:bintray-client-java-service:0.4')
+    testImplementation('com.jfrog.bintray.client:bintray-client-java-impl:0.1.1')
+    testImplementation('org.codehaus.gpars:gpars:1.2.1')
+    testImplementation('org.codehaus.groovy.modules.http-builder:http-builder:0.7.1')
 }
 
 test {

--- a/src/test/resources/gradle/projects/configurationWithSubModules/api/build.gradle
+++ b/src/test/resources/gradle/projects/configurationWithSubModules/api/build.gradle
@@ -43,7 +43,3 @@ def getTestFile = { fileName ->
 }
 
 apply from: getTestFile("${testName}.gradle")
-
-task wrapper(type: Wrapper) {
-    gradleVersion = '2.4'
-}

--- a/src/test/resources/gradle/projects/configurationWithSubModules/shared/build.gradle
+++ b/src/test/resources/gradle/projects/configurationWithSubModules/shared/build.gradle
@@ -43,7 +43,3 @@ def getTestFile = { fileName ->
 }
 
 apply from: getTestFile("${testName}.gradle")
-
-task wrapper(type: Wrapper) {
-    gradleVersion = '2.4'
-}


### PR DESCRIPTION
This aligns the artifact collection logic with the one from the Artifactory plugin and enables deploying Gradle Module Metadata files to Bintray.

This PR replaces #230 by leveraging APIs introduced in Gradle 4.8, which becomes the minimum requirement.

Tests have been run with the default setup and a `GRADLE_HOME` set to version 6.0.1 to verify the upload of `*.module` files.