### PR TITLE
Update to HTTPS urls in BintrayRepositoriesExtension

### DIFF
--- a/gradle/Bintray.gradle
+++ b/gradle/Bintray.gradle
@@ -32,7 +32,7 @@ class BintrayRepositoriesExtension {
     MavenArtifactRepository jcenter() {
         return repositories.maven { MavenArtifactRepository repository ->
             repository.name = 'BintrayJCenter'
-            repository.url = 'http://jcenter.bintray.com'
+            repository.url = 'https://jcenter.bintray.com'
         }
     }
 
@@ -90,7 +90,7 @@ class BintrayRepositoriesExtension {
     }
 
     String determineRepositoryUrl(String repoOwner, String repoName) {
-        return "http://dl.bintray.com/content/${repoOwner}/${repoName}"
+        return "https://dl.bintray.com/content/${repoOwner}/${repoName}"
     }
 
     String separatorsToCaps(String string) {


### PR DESCRIPTION
Hi,

this PR updates two URLs to make use of HTTPS. This seems especially important for  http://jcenter.bintray.com as this seems to be effectively turned off.

Cheers,
Christoph