### PR TITLE
Switch dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,7 +27,10 @@ dependencies {
     compile('org.codehaus.groovy.modules.http-builder:http-builder:0.7.2') {
         exclude(module: 'groovy')
     }
-    compile('org.apache.maven:maven-ant-tasks:2.1.3')
+    compile('org.apache.maven.resolver:maven-resolver-ant-tasks:1.2.0')
+    // provided by Gradle
+    compileOnly('org.apache.maven:maven-project:2.0.11')
+    testRuntime('org.apache.maven:maven-project:2.0.11')
     testCompile('org.spockframework:spock-core:0.7-groovy-2.0') {
         exclude(module: 'groovy-all')
     }


### PR DESCRIPTION
Fix for #318 
- maven-ant-tasks is no longer supported
- maven-resolver-and-tasks is the replacement